### PR TITLE
Right-click color picking fixed on firefox?

### DIFF
--- a/front/main.js
+++ b/front/main.js
@@ -181,6 +181,8 @@ displayCanvas.addEventListener('pointerup', (event) => {
             || (dy == 0 && dx == 0))
         // Not redrawing
         && data[y()][x()] != COLORS.indexOf(drawColor)
+		// Actually a left click
+		&& event.isPrimary
     ) {
         lastClick = Date.now();
 


### PR DESCRIPTION
This should fix right-click not picking a color on Firefox by checking if the `pointerup` event is a primary click